### PR TITLE
Bugfix for ownerships

### DIFF
--- a/src/com/shepherdjerred/sthorses/listeners/InteractEvent.java
+++ b/src/com/shepherdjerred/sthorses/listeners/InteractEvent.java
@@ -114,7 +114,7 @@ public class InteractEvent implements Listener {
 									horse.setAge(Integer.parseInt(itemLore.get(9).replace("Age: ", "")));
 
 									// Set the owner
-									horse.setOwner((AnimalTamer) Main.getInstance().getServer().getPlayer((UUID.fromString(itemLore.get(10).replace("UUID: ", "")))));
+									horse.setOwner((AnimalTamer) Main.getInstance().getServer().getOfflinePlayer((UUID.fromString(itemLore.get(10).replace("UUID: ", "")))));
 
 									// Give the horse a saddle
 									horse.getInventory().setSaddle(new ItemStack(Material.SADDLE, 1));


### PR DESCRIPTION
Added an offline player support to prevent respawning untamed horses with saddle.

Because an untamed horse with a saddle is rideable but not tameable and no inventory opens. So you can't despawn that horse again.