### PR TITLE
Multiple commits

### DIFF
--- a/src/main/java/com/shepherdjerred/sthorses/listeners/PlaceListener.java
+++ b/src/main/java/com/shepherdjerred/sthorses/listeners/PlaceListener.java
@@ -64,7 +64,7 @@ public class PlaceListener implements Listener {
                 event.getClickedBlock().getY() + 1,
                 event.getClickedBlock().getZ());
 
-        AbstractHorse abstractHorse = createAbstractHorse(itemMeta, spawnLocation);
+        AbstractHorse abstractHorse = createAbstractHorse(itemMeta, spawnLocation, player);
 
         // Something went wrong, let's stop
         if (abstractHorse == null) {
@@ -75,7 +75,7 @@ public class PlaceListener implements Listener {
 
     }
 
-    private AbstractHorse createAbstractHorse(ItemMeta itemMeta, Location location) {
+    private AbstractHorse createAbstractHorse(ItemMeta itemMeta, Location location, Player spawner) {
 
         List<String> lore = itemMeta.getLore();
 
@@ -134,6 +134,8 @@ public class PlaceListener implements Listener {
 
         if (!ownerUuid.equals("None")) {
             abstractHorse.setOwner(Bukkit.getOfflinePlayer(UUID.fromString(ownerUuid)));
+        } else {
+            abstractHorse.setOwner(Bukkit.getOfflinePlayer(spawner.getUniqueId()));
         }
 
         String[] horseHealth = health.replace("Health: ", "").split("/");

--- a/src/main/java/com/shepherdjerred/sthorses/listeners/StoreListener.java
+++ b/src/main/java/com/shepherdjerred/sthorses/listeners/StoreListener.java
@@ -5,6 +5,7 @@ import com.shepherdjerred.sthorses.util.ItemUtils;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.ChestedHorse;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Llama;
 import org.bukkit.entity.Player;
@@ -88,6 +89,15 @@ public class StoreListener implements Listener {
         ItemUtils.addGlow(saddle);
 
         event.setCurrentItem(new ItemStack(Material.AIR));
+
+        // Drop the horses chest, if carrying
+        if (abstractHorse instanceof ChestedHorse) {
+            ChestedHorse chestedHorse = (ChestedHorse) abstractHorse;
+            if (chestedHorse.isCarryingChest()) {
+                ItemStack chestToDrop = new ItemStack(Material.CHEST, 1);
+                chestedHorse.getWorld().dropItem(chestedHorse.getLocation(), chestToDrop);
+            }
+        }
 
         // Drop the horses inventory
         abstractHorse.getInventory().forEach(item -> {


### PR DESCRIPTION
**setOwner for tamed but unowned horses**
Skeleton horses are tamed but unowned. Restoring caused a faulty entity,
fixed with a new owner.

Fixes #18 

**Drop equiped chest**
A chest is dropped if the horse is carrying one

Fixes #20 